### PR TITLE
Fixed width error in case statement in the signext.sv on the md file single_cycle_edition

### DIFF
--- a/single_cycle_edition/single_cycle_edition.md
+++ b/single_cycle_edition/single_cycle_edition.md
@@ -478,7 +478,7 @@ logic [11:0] gathered_imm;
 
 always_comb begin
     case (imm_source)
-        1'b00 : gathered_imm = raw_src[24:13];
+        2'b00 : gathered_imm = raw_src[24:13];
         default: gathered_imm = 12'b0;
     endcase
 end


### PR DESCRIPTION
Hey, 
I changed the signal width to the right one, so instead of 1'b00, it's 2'b00 because imm_source is a 2-bit signal.