### PR TITLE
Preventing an 'IndexError: list index out of range

### DIFF
--- a/single_cycle_edition/single_cycle_edition.md
+++ b/single_cycle_edition/single_cycle_edition.md
@@ -478,7 +478,7 @@ logic [11:0] gathered_imm;
 
 always_comb begin
     case (imm_source)
-        1'b00 : gathered_imm = raw_src[24:13];
+        2'b00 : gathered_imm = raw_src[24:13];
         default: gathered_imm = 12'b0;
     endcase
 end

--- a/single_cycle_edition/single_cycle_edition.md
+++ b/single_cycle_edition/single_cycle_edition.md
@@ -930,6 +930,8 @@ Which translates as this in HEX format (comments like ```//blablabla``` are igno
 00802903  //LW TEST START : lw x18 8(x0)
 00000013  //NOP
 00000013  //NOP
+00000013  //NOP
+00000013  //NOP
 //(Filled the rest with NOPs...) 
 ```
 


### PR DESCRIPTION
To ensure the code functions correctly when the `test_imemory.hex` file has fewer than five lines, I've inserted two `NOP` lines. This prevents an `IndexError: list index out of range` error by guaranteeing there are enough lines to avoid accessing an invalid index.