### PR TITLE
Replace display error by fatal error for misaligned write

### DIFF
--- a/0_single_cycle_edition/src/memory.sv
+++ b/0_single_cycle_edition/src/memory.sv
@@ -44,7 +44,7 @@ always @(posedge clk) begin
     end else begin
         if(write_enable) begin
             if (address[1:0] != 2'b00) begin
-                $display("Misaligned write at address %h", address);
+                $fatal("STOPPING SIMULATION: Misaligned write at address %h. HINT: Check your code.", address);
             end else begin
                 // use byte-enable to selectively write bytes
                 for (int i = 0; i < 4; i++) begin


### PR DESCRIPTION
Instead of just printing out an error message, we should generally raise an exception to stop an incorrect program from executing further