### PR TITLE
Refactor offset assignment in load_store_decoder

### DIFF
--- a/0_single_cycle_edition/src/load_store_decoder.sv
+++ b/0_single_cycle_edition/src/load_store_decoder.sv
@@ -20,9 +20,10 @@ import holy_core_pkg::*;
 
 logic [1:0] offset;
 
-assign offset = alu_result_address[1:0];
-
 always_comb begin
+
+    offset = alu_result_address[1:0];
+
     case (f3)
         F3_BYTE, F3_BYTE_U : begin // SB, LB, LBU
             case (offset)


### PR DESCRIPTION
Move offset assignment from a single assign statement to the unified always_comb block (does the same thing but makes the script look a lot cleaner ;))