### PR TITLE
Remove @cocotb.coroutine for set_unknown function

### DIFF
--- a/0_single_cycle_edition/tb/control/test_control.py
+++ b/0_single_cycle_edition/tb/control/test_control.py
@@ -7,9 +7,8 @@ from cocotb.triggers import Timer
 import random
 from cocotb.binary import BinaryValue
 
-@cocotb.coroutine
 async def set_unknown(dut):
-    # Set all input to unknown before each test
+    # Set all inputs to unknown before each test
     await Timer(1, units="ns")
     dut.op.value = BinaryValue("XXXXXXX")
     dut.func3.value = BinaryValue("XXX")


### PR DESCRIPTION
Just use `async def` (cocotb modern standard), `@cocotb.coroutine` is deprecated for subroutines