### PR TITLE
[single-cycle] style: inner-module indentation, lowRISC-compliant tabular-style port blocks, and minor changes

### DIFF
--- a/0_single_cycle_edition/src/alu.sv
+++ b/0_single_cycle_edition/src/alu.sv
@@ -3,51 +3,51 @@
 *
 * BRH 10/24
 *
-* Simple and non efficient ALU.
+* A simple and non-efficient ALU.
 */
 
 `timescale 1ns/1ps
 
 module alu (
-    input  logic [3:0]  alu_control,
-    input  logic [31:0] src1,
-    input  logic [31:0] src2,
-    output logic [31:0] alu_result,
-    output logic        zero,
-    output logic        last_bit
+  input  logic [3:0]  alu_control,
+  input  logic [31:0] src1,
+  input  logic [31:0] src2,
+  output logic [31:0] alu_result,
+  output logic        zero,
+  output logic        last_bit
 );
 
-import holy_core_pkg::*;
+  import holy_core_pkg::*;
 
-wire [4:0] shamt = src2[4:0];
+  wire [4:0] shamt = src2[4:0];
 
-always_comb begin
+  always_comb begin
     case (alu_control)
-        // ADD STUFF
-        ALU_ADD : alu_result = src1 + src2;
-        // AND STUFF
-        ALU_AND : alu_result = src1 & src2;
-        // OR STUFF
-        ALU_OR : alu_result = src1 | src2;
-        // SUB Stuff (src1 - src2)
-        ALU_SUB : alu_result = src1 + (~src2 + 1'b1);
-        // LESS THAN COMPARE STUFF (src1 < src2)
-        ALU_SLT : alu_result = {31'b0, $signed(src1) < $signed(src2)};
-        // LESS THAN COMPARE STUFF (src1 < src2) (UNSIGNED VERSION)
-        ALU_SLTU : alu_result = {31'b0, src1 < src2};
-        // XOR STUFF
-        ALU_XOR : alu_result = src1 ^ src2;
-        // SLL STUFF
-        ALU_SLL : alu_result = src1 << shamt;
-        // SRL STUFF
-        ALU_SRL : alu_result = src1 >> shamt;
-        // SRA STUFF
-        ALU_SRA : alu_result = $signed(src1) >>> shamt;
-        default : alu_result = 32'd0;
+      // ADD
+      ALU_ADD: alu_result = src1 + src2;
+      // AND
+      ALU_AND: alu_result = src1 & src2;
+      // OR
+      ALU_OR: alu_result = src1 | src2;
+      // SUB (src1 - src2)
+      ALU_SUB: alu_result = src1 + (~src2 + 1'b1);
+      // SLT (compare less than) (src1 < src2)
+      ALU_SLT: alu_result = {31'b0, $signed(src1) < $signed(src2)};
+      // SLTU (compare less than) (src1 < src2) (unsigned version)
+      ALU_SLTU: alu_result = {31'b0, src1 < src2};
+      // XOR
+      ALU_XOR: alu_result = src1 ^ src2;
+      // SLL
+      ALU_SLL: alu_result = src1 << shamt;
+      // SRL
+      ALU_SRL: alu_result = src1 >> shamt;
+      // SRA
+      ALU_SRA: alu_result = $signed(src1) >>> shamt;
+      default: alu_result = 32'd0;
     endcase
-end
+  end
 
-assign zero = alu_result == 32'b0;
-assign last_bit = alu_result[0];
-    
-endmodule
+  assign zero = alu_result == 32'b0;
+  assign last_bit = alu_result[0];
+
+endmodule : alu

--- a/0_single_cycle_edition/src/alu.sv
+++ b/0_single_cycle_edition/src/alu.sv
@@ -9,45 +9,45 @@
 `timescale 1ns/1ps
 
 module alu (
-  input  logic [3:0]  alu_control,
-  input  logic [31:0] src1,
-  input  logic [31:0] src2,
-  output logic [31:0] alu_result,
-  output logic        zero,
-  output logic        last_bit
+    input  logic [3:0]  alu_control,
+    input  logic [31:0] src1,
+    input  logic [31:0] src2,
+    output logic [31:0] alu_result,
+    output logic        zero,
+    output logic        last_bit
 );
 
-  import holy_core_pkg::*;
+    import holy_core_pkg::*;
 
-  wire [4:0] shamt = src2[4:0];
+    wire [4:0] shamt = src2[4:0];
 
-  always_comb begin
+    always_comb begin
     case (alu_control)
-      // ADD
-      ALU_ADD: alu_result = src1 + src2;
-      // AND
-      ALU_AND: alu_result = src1 & src2;
-      // OR
-      ALU_OR: alu_result = src1 | src2;
-      // SUB (src1 - src2)
-      ALU_SUB: alu_result = src1 + (~src2 + 1'b1);
-      // SLT (compare less than) (src1 < src2)
-      ALU_SLT: alu_result = {31'b0, $signed(src1) < $signed(src2)};
-      // SLTU (compare less than) (src1 < src2) (unsigned version)
-      ALU_SLTU: alu_result = {31'b0, src1 < src2};
-      // XOR
-      ALU_XOR: alu_result = src1 ^ src2;
-      // SLL
-      ALU_SLL: alu_result = src1 << shamt;
-      // SRL
-      ALU_SRL: alu_result = src1 >> shamt;
-      // SRA
-      ALU_SRA: alu_result = $signed(src1) >>> shamt;
-      default: alu_result = 32'd0;
+        // ADD
+        ALU_ADD: alu_result = src1 + src2;
+        // AND
+        ALU_AND: alu_result = src1 & src2;
+        // OR
+        ALU_OR: alu_result = src1 | src2;
+        // SUB (src1 - src2)
+        ALU_SUB: alu_result = src1 + (~src2 + 1'b1);
+        // SLT (compare less than) (src1 < src2)
+        ALU_SLT: alu_result = {31'b0, $signed(src1) < $signed(src2)};
+        // SLTU (compare less than) (src1 < src2) (unsigned version)
+        ALU_SLTU: alu_result = {31'b0, src1 < src2};
+        // XOR
+        ALU_XOR: alu_result = src1 ^ src2;
+        // SLL
+        ALU_SLL: alu_result = src1 << shamt;
+        // SRL
+        ALU_SRL: alu_result = src1 >> shamt;
+        // SRA
+        ALU_SRA: alu_result = $signed(src1) >>> shamt;
+        default: alu_result = 32'd0;
     endcase
-  end
+    end
 
-  assign zero = alu_result == 32'b0;
-  assign last_bit = alu_result[0];
+    assign zero = alu_result == 32'b0;
+    assign last_bit = alu_result[0];
 
 endmodule : alu

--- a/0_single_cycle_edition/src/control.sv
+++ b/0_single_cycle_edition/src/control.sv
@@ -9,223 +9,225 @@
 `timescale 1ns/1ps
 
 module control (
-  input  logic [6:0] op,
-  input  logic [2:0] func3,
-  input  logic [6:0] func7,
-  input  logic       alu_zero,
-  input  logic       alu_last_bit,
-  output logic [3:0] alu_control,
-  output logic [2:0] imm_source,
-  output logic       mem_write,
-  output logic       reg_write,
-  output logic       alu_source,
-  output logic [1:0] write_back_source,
-  output logic       pc_source,
-  output logic [1:0] second_add_source
+    input  logic [6:0] op,
+    input  logic [2:0] func3,
+    input  logic [6:0] func7,
+    input  logic       alu_zero,
+    input  logic       alu_last_bit,
+    output logic [3:0] alu_control,
+    output logic [2:0] imm_source,
+    output logic       mem_write,
+    output logic       reg_write,
+    output logic       alu_source,
+    output logic [1:0] write_back_source,
+    output logic       pc_source,
+    output logic [1:0] second_add_source
 );
 
-  import holy_core_pkg::*;
+    import holy_core_pkg::*;
 
-  /**
-  * MAIN DECODER
-  */
+    /**
+    * MAIN DECODER
+    */
 
-  logic [1:0] alu_op;
-  logic branch;
-  logic jump;
+    logic [1:0] alu_op;
+    logic branch;
+    logic jump;
 
-  always_comb begin
-    case (op)
-      // I-type
-      OPCODE_I_TYPE_LOAD: begin
-        reg_write = 1'b1;
-        imm_source = 3'b000;
-        mem_write = 1'b0;
-        alu_op = 2'b00;
-        alu_source = 1'b1; //imm
-        write_back_source =2'b01; //memory_read
-        branch = 1'b0;
-        jump = 1'b0;
-      end
-      // ALU I-type
-      OPCODE_I_TYPE_ALU: begin
-        imm_source = 3'b000;
-        alu_source = 1'b1; //imm
-        mem_write = 1'b0;
-        alu_op = 2'b10;
-        write_back_source = 2'b00; //alu_result
-        branch = 1'b0;
-        jump = 1'b0;
-        // If we have a shift with a constant to handle, we have to invalidate writes for
-        // instructions that does not have a well-formated immediate with "f7" and a 5bits shamt
-        // ie:
-        // - 7 upper bits are interpreted as a "f7", ony valid for a restricted slection tested below
-        // - 5 lower as shamt (because max shift is 32bits and 2^5 = 32).
-        if(func3 == F3_SLL)begin
-          // slli only accept f7 7'b0000000
-          reg_write = (func7 == F7_SLL_SRL) ? 1'b1: 1'b0;
-        end
-        else if(func3 == F3_SRL_SRA)begin
-          // srli only accept f7 7'b0000000
-          // srai only accept f7 7'b0100000
-          reg_write = (func7 == F7_SLL_SRL | func7 == F7_SRA) ? 1'b1: 1'b0;
-        end else begin
-          reg_write = 1'b1;
-        end
-      end
-      // S-Type
-      OPCODE_S_TYPE: begin
-        reg_write = 1'b0;
-        imm_source = 3'b001;
-        mem_write = 1'b1;
-        alu_op = 2'b00;
-        alu_source = 1'b1; //imm
-        branch = 1'b0;
-        jump = 1'b0;
-      end
-      // R-Type
-      OPCODE_R_TYPE: begin
-        reg_write = 1'b1;
-        mem_write = 1'b0;
-        alu_op = 2'b10;
-        alu_source = 1'b0; //reg2
-        write_back_source = 2'b00; //alu_result
-        branch = 1'b0;
-        jump = 1'b0;
-      end
-      // B-type
-      OPCODE_B_TYPE: begin
-        reg_write = 1'b0;
-        imm_source = 3'b010;
-        alu_source = 1'b0;
-        mem_write = 1'b0;
-        alu_op = 2'b01;
-        branch = 1'b1;
-        jump = 1'b0;
-        second_add_source = 2'b00;
-      end
-      // J-type + JALR weird Hybrib
-      OPCODE_J_TYPE, OPCODE_J_TYPE_JALR: begin
-        reg_write = 1'b1;
-        imm_source = 3'b011;
-        mem_write = 1'b0;
-        write_back_source = 2'b10; //pc_+4
-        branch = 1'b0;
-        jump = 1'b1;
-        if(op[3]) begin// jal
-          second_add_source = 2'b00;
-          imm_source = 3'b011;
-        end
-        else if (~op[3]) begin // jalr
-          second_add_source = 2'b10;
-          imm_source = 3'b000;
-        end
-      end
-      // U-type
-      OPCODE_U_TYPE_LUI, OPCODE_U_TYPE_AUIPC: begin
-        imm_source = 3'b100;
-        mem_write = 1'b0;
-        reg_write = 1'b1;
-        write_back_source = 2'b11;
-        branch = 1'b0;
-        jump = 1'b0;
-        case(op[5])
-          1'b1: second_add_source = 2'b01; // lui
-          1'b0: second_add_source = 2'b00; // auipc
-        endcase
-      end
-      // EVERYTHING ELSE
-      default: begin
-        // Don't touch the CPU nor MEMORY state
-        reg_write = 1'b0;
-        mem_write = 1'b0;
-        jump = 1'b0;
-        branch = 1'b0;
-        $display("Unknown/unsupported opcode!");
-      end
-    endcase
-  end
-
-  /**
-  * ALU DECODER
-  */
-
-  always_comb begin
-    case (alu_op)
-      // LW, SW
-      ALU_OP_LOAD_STORE: alu_control = ALU_ADD;
-      // R-Types, I-types
-      ALU_OP_MATH: begin
-        case (func3)
-          // ADD (and later SUB with a different F7)
-          F3_ADD_SUB: begin
-            // 2 scenarios here:
-            // - R-TYPE: either add or sub and we need to a check for that
-            // - I-Type: aadi -> we use add arithmetic
-            if(op == 7'b0110011) begin // R-type
-                alu_control = (func7 == F7_SUB)? ALU_SUB: ALU_ADD;
-            end else begin // I-Type
-                alu_control = ALU_ADD;
+    always_comb begin
+        case (op)
+            // I-type
+            OPCODE_I_TYPE_LOAD: begin
+                reg_write = 1'b1;
+                imm_source = 3'b000;
+                mem_write = 1'b0;
+                alu_op = 2'b00;
+                alu_source = 1'b1; //imm
+                write_back_source =2'b01; //memory_read
+                branch = 1'b0;
+                jump = 1'b0;
             end
-          end
-          // AND
-          F3_AND: alu_control = ALU_AND;
-          // OR
-          F3_OR: alu_control = ALU_OR;
-          // SLT, SLTI
-          F3_SLT: alu_control = ALU_SLT;
-          // SLTU, SLTIU
-          F3_SLTU: alu_control = ALU_SLTU;
-          // XOR
-          F3_XOR: alu_control = ALU_XOR;
-          // SLL
-          F3_SLL: alu_control = ALU_SLL;
-          // SRL, SRA
-          F3_SRL_SRA: begin
-            if(func7 == F7_SLL_SRL) begin
-              alu_control = ALU_SRL; // srl
-            end else if (func7 == F7_SRA) begin
-              alu_control = ALU_SRA; // sra
+            // ALU I-type
+            OPCODE_I_TYPE_ALU: begin
+                imm_source = 3'b000;
+                alu_source = 1'b1; //imm
+                mem_write = 1'b0;
+                alu_op = 2'b10;
+                write_back_source = 2'b00; //alu_result
+                branch = 1'b0;
+                jump = 1'b0;
+                // If we have a shift with a constant to handle, we have to invalidate writes for
+                // instructions that does not have a well-formated immediate with "f7" and a 5bits shamt
+                // ie:
+                // - 7 upper bits are interpreted as a "f7", ony valid for a restricted slection tested below
+                // - 5 lower as shamt (because max shift is 32bits and 2^5 = 32).
+                if(func3 == F3_SLL)begin
+                    // slli only accept f7 7'b0000000
+                    reg_write = (func7 == F7_SLL_SRL) ? 1'b1: 1'b0;
+                end
+                else if(func3 == F3_SRL_SRA)begin
+                    // srli only accept f7 7'b0000000
+                    // srai only accept f7 7'b0100000
+                    reg_write = (func7 == F7_SLL_SRL | func7 == F7_SRA) ? 1'b1: 1'b0;
+                end else begin
+                    reg_write = 1'b1;
+                end
             end
-          end
+            // S-Type
+            OPCODE_S_TYPE: begin
+                reg_write = 1'b0;
+                imm_source = 3'b001;
+                mem_write = 1'b1;
+                alu_op = 2'b00;
+                alu_source = 1'b1; //imm
+                branch = 1'b0;
+                jump = 1'b0;
+            end
+            // R-Type
+            OPCODE_R_TYPE: begin
+                reg_write = 1'b1;
+                mem_write = 1'b0;
+                alu_op = 2'b10;
+                alu_source = 1'b0; //reg2
+                write_back_source = 2'b00; //alu_result
+                branch = 1'b0;
+                jump = 1'b0;
+            end
+            // B-type
+            OPCODE_B_TYPE: begin
+                reg_write = 1'b0;
+                imm_source = 3'b010;
+                alu_source = 1'b0;
+                mem_write = 1'b0;
+                alu_op = 2'b01;
+                branch = 1'b1;
+                jump = 1'b0;
+                second_add_source = 2'b00;
+            end
+            // J-type + JALR weird Hybrib
+            OPCODE_J_TYPE, OPCODE_J_TYPE_JALR: begin
+                reg_write = 1'b1;
+                imm_source = 3'b011;
+                mem_write = 1'b0;
+                write_back_source = 2'b10; //pc_+4
+                branch = 1'b0;
+                jump = 1'b1;
+                if(op[3]) begin// jal
+                    second_add_source = 2'b00;
+                    imm_source = 3'b011;
+                end
+                else if (~op[3]) begin // jalr
+                    second_add_source = 2'b10;
+                    imm_source = 3'b000;
+                end
+            end
+            // U-type
+            OPCODE_U_TYPE_LUI, OPCODE_U_TYPE_AUIPC: begin
+                imm_source = 3'b100;
+                mem_write = 1'b0;
+                reg_write = 1'b1;
+                write_back_source = 2'b11;
+                branch = 1'b0;
+                jump = 1'b0;
+                case(op[5])
+                    1'b1: second_add_source = 2'b01; // lui
+                    1'b0: second_add_source = 2'b00; // auipc
+                    default: ;
+                endcase
+            end
+            // EVERYTHING ELSE
+            default: begin
+                // Don't touch the CPU nor MEMORY state
+                reg_write = 1'b0;
+                mem_write = 1'b0;
+                jump = 1'b0;
+                branch = 1'b0;
+                $display("Unknown/unsupported opcode!");
+            end
         endcase
-      end
-      // BRANCHES
-      ALU_OP_BRANCHES: begin
+    end
+
+    /**
+    * ALU DECODER
+    */
+
+    always_comb begin
+        case (alu_op)
+            // LW, SW
+            ALU_OP_LOAD_STORE: alu_control = ALU_ADD;
+            // R-Types, I-types
+            ALU_OP_MATH: begin
+                case (func3)
+                    // ADD (and later SUB with a different F7)
+                    F3_ADD_SUB: begin
+                        // 2 scenarios here:
+                        // - R-TYPE: either add or sub and we need to a check for that
+                        // - I-Type: aadi -> we use add arithmetic
+                        if(op == 7'b0110011) begin // R-type
+                            alu_control = (func7 == F7_SUB)? ALU_SUB: ALU_ADD;
+                        end else begin // I-Type
+                            alu_control = ALU_ADD;
+                        end
+                    end
+                    // AND
+                    F3_AND: alu_control = ALU_AND;
+                    // OR
+                    F3_OR: alu_control = ALU_OR;
+                    // SLT, SLTI
+                    F3_SLT: alu_control = ALU_SLT;
+                    // SLTU, SLTIU
+                    F3_SLTU: alu_control = ALU_SLTU;
+                    // XOR
+                    F3_XOR: alu_control = ALU_XOR;
+                    // SLL
+                    F3_SLL: alu_control = ALU_SLL;
+                    // SRL, SRA
+                    F3_SRL_SRA: begin
+                        if(func7 == F7_SLL_SRL) begin
+                            alu_control = ALU_SRL; // srl
+                        end else if (func7 == F7_SRA) begin
+                            alu_control = ALU_SRA; // sra
+                        end
+                    end
+                    default: ;
+                endcase
+            end
+            // BRANCHES
+            ALU_OP_BRANCHES: begin
+                case (func3)
+                    // BEQ, BNE
+                    F3_BEQ, F3_BNE: alu_control = 4'b0001;
+                    // BLT, BGE
+                    F3_BLT, F3_BGE: alu_control = 4'b0101;
+                    // BLTU, BGEU
+                    F3_BLTU, F3_BGEU: alu_control = 4'b0111;
+                    default: alu_control = 4'b1111;
+                endcase
+            end
+            default: alu_control = 4'b1111;
+        endcase
+    end
+
+    /**
+    * PC_Source
+    */
+
+    logic assert_branch;
+
+    always_comb begin: branch_logic_decode
         case (func3)
-          // BEQ, BNE
-          F3_BEQ, F3_BNE: alu_control = 4'b0001;
-          // BLT, BGE
-          F3_BLT, F3_BGE: alu_control = 4'b0101;
-          // BLTU, BGEU
-          F3_BLTU, F3_BGEU: alu_control = 4'b0111;
-          default: alu_control = 4'b1111;
+            // BEQ
+            F3_BEQ: assert_branch = alu_zero & branch;
+            // BLT, BLTU
+            F3_BLT, F3_BLTU: assert_branch = alu_last_bit & branch;
+            // BNE
+            F3_BNE: assert_branch = ~alu_zero & branch;
+            // BGE, BGEU
+            F3_BGE, F3_BGEU: assert_branch = ~alu_last_bit & branch;
+            default: assert_branch = 1'b0;
         endcase
-      end
-      default: alu_control = 4'b1111;
-    endcase
-  end
+    end
 
-  /**
-  * PC_Source
-  */
-
-  logic assert_branch;
-
-  always_comb begin: branch_logic_decode
-    case (func3)
-      // BEQ
-      F3_BEQ: assert_branch = alu_zero & branch;
-      // BLT, BLTU
-      F3_BLT, F3_BLTU: assert_branch = alu_last_bit & branch;
-      // BNE
-      F3_BNE: assert_branch = ~alu_zero & branch;
-      // BGE, BGEU
-      F3_BGE, F3_BGEU: assert_branch = ~alu_last_bit & branch;
-      default: assert_branch = 1'b0;
-    endcase
-  end
-
-  assign pc_source = assert_branch | jump;
+    assign pc_source = assert_branch | jump;
 
 endmodule : control

--- a/0_single_cycle_edition/src/control.sv
+++ b/0_single_cycle_edition/src/control.sv
@@ -9,223 +9,223 @@
 `timescale 1ns/1ps
 
 module control (
-    input  logic [6:0] op,
-    input  logic [2:0] func3,
-    input  logic [6:0] func7,
-    input  logic       alu_zero,
-    input  logic       alu_last_bit,
-    output logic [3:0] alu_control,
-    output logic [2:0] imm_source,
-    output logic       mem_write,
-    output logic       reg_write,
-    output logic       alu_source,
-    output logic [1:0] write_back_source,
-    output logic       pc_source,
-    output logic [1:0] second_add_source
+  input  logic [6:0] op,
+  input  logic [2:0] func3,
+  input  logic [6:0] func7,
+  input  logic       alu_zero,
+  input  logic       alu_last_bit,
+  output logic [3:0] alu_control,
+  output logic [2:0] imm_source,
+  output logic       mem_write,
+  output logic       reg_write,
+  output logic       alu_source,
+  output logic [1:0] write_back_source,
+  output logic       pc_source,
+  output logic [1:0] second_add_source
 );
 
-import holy_core_pkg::*;
+  import holy_core_pkg::*;
 
-/**
-* MAIN DECODER
-*/
+  /**
+  * MAIN DECODER
+  */
 
-logic [1:0] alu_op;
-logic branch;
-logic jump;
+  logic [1:0] alu_op;
+  logic branch;
+  logic jump;
 
-always_comb begin
+  always_comb begin
     case (op)
-        // I-type
-        OPCODE_I_TYPE_LOAD : begin
-            reg_write = 1'b1;
-            imm_source = 3'b000;
-            mem_write = 1'b0;
-            alu_op = 2'b00;
-            alu_source = 1'b1; //imm
-            write_back_source =2'b01; //memory_read
-            branch = 1'b0;
-            jump = 1'b0;
+      // I-type
+      OPCODE_I_TYPE_LOAD: begin
+        reg_write = 1'b1;
+        imm_source = 3'b000;
+        mem_write = 1'b0;
+        alu_op = 2'b00;
+        alu_source = 1'b1; //imm
+        write_back_source =2'b01; //memory_read
+        branch = 1'b0;
+        jump = 1'b0;
+      end
+      // ALU I-type
+      OPCODE_I_TYPE_ALU: begin
+        imm_source = 3'b000;
+        alu_source = 1'b1; //imm
+        mem_write = 1'b0;
+        alu_op = 2'b10;
+        write_back_source = 2'b00; //alu_result
+        branch = 1'b0;
+        jump = 1'b0;
+        // If we have a shift with a constant to handle, we have to invalidate writes for
+        // instructions that does not have a well-formated immediate with "f7" and a 5bits shamt
+        // ie:
+        // - 7 upper bits are interpreted as a "f7", ony valid for a restricted slection tested below
+        // - 5 lower as shamt (because max shift is 32bits and 2^5 = 32).
+        if(func3 == F3_SLL)begin
+          // slli only accept f7 7'b0000000
+          reg_write = (func7 == F7_SLL_SRL) ? 1'b1: 1'b0;
         end
-        // ALU I-type
-        OPCODE_I_TYPE_ALU : begin
-            imm_source = 3'b000;
-            alu_source = 1'b1; //imm
-            mem_write = 1'b0;
-            alu_op = 2'b10;
-            write_back_source = 2'b00; //alu_result
-            branch = 1'b0;
-            jump = 1'b0;
-            // If we have a shift with a constant to handle, we have to invalidate writes for
-            // instructions that does not have a well-formated immediate with "f7" and a 5bits shamt
-            // ie :
-            // - 7 upper bits are interpreted as a "f7", ony valid for a restricted slection tested below
-            // - 5 lower as shamt (because max shift is 32bits and 2^5 = 32).
-            if(func3 == F3_SLL)begin
-                // slli only accept f7 7'b0000000
-                reg_write = (func7 == F7_SLL_SRL) ? 1'b1 : 1'b0;
-            end
-            else if(func3 == F3_SRL_SRA)begin
-                // srli only accept f7 7'b0000000
-                // srai only accept f7 7'b0100000
-                reg_write = (func7 == F7_SLL_SRL | func7 == F7_SRA) ? 1'b1 : 1'b0;
-            end else begin
-                reg_write = 1'b1;
-            end
+        else if(func3 == F3_SRL_SRA)begin
+          // srli only accept f7 7'b0000000
+          // srai only accept f7 7'b0100000
+          reg_write = (func7 == F7_SLL_SRL | func7 == F7_SRA) ? 1'b1: 1'b0;
+        end else begin
+          reg_write = 1'b1;
         end
-        // S-Type
-        OPCODE_S_TYPE : begin
-            reg_write = 1'b0;
-            imm_source = 3'b001;
-            mem_write = 1'b1;
-            alu_op = 2'b00;
-            alu_source = 1'b1; //imm
-            branch = 1'b0;
-            jump = 1'b0;
+      end
+      // S-Type
+      OPCODE_S_TYPE: begin
+        reg_write = 1'b0;
+        imm_source = 3'b001;
+        mem_write = 1'b1;
+        alu_op = 2'b00;
+        alu_source = 1'b1; //imm
+        branch = 1'b0;
+        jump = 1'b0;
+      end
+      // R-Type
+      OPCODE_R_TYPE: begin
+        reg_write = 1'b1;
+        mem_write = 1'b0;
+        alu_op = 2'b10;
+        alu_source = 1'b0; //reg2
+        write_back_source = 2'b00; //alu_result
+        branch = 1'b0;
+        jump = 1'b0;
+      end
+      // B-type
+      OPCODE_B_TYPE: begin
+        reg_write = 1'b0;
+        imm_source = 3'b010;
+        alu_source = 1'b0;
+        mem_write = 1'b0;
+        alu_op = 2'b01;
+        branch = 1'b1;
+        jump = 1'b0;
+        second_add_source = 2'b00;
+      end
+      // J-type + JALR weird Hybrib
+      OPCODE_J_TYPE, OPCODE_J_TYPE_JALR: begin
+        reg_write = 1'b1;
+        imm_source = 3'b011;
+        mem_write = 1'b0;
+        write_back_source = 2'b10; //pc_+4
+        branch = 1'b0;
+        jump = 1'b1;
+        if(op[3]) begin// jal
+          second_add_source = 2'b00;
+          imm_source = 3'b011;
         end
-        // R-Type
-        OPCODE_R_TYPE : begin
-            reg_write = 1'b1;
-            mem_write = 1'b0;
-            alu_op = 2'b10;
-            alu_source = 1'b0; //reg2
-            write_back_source = 2'b00; //alu_result
-            branch = 1'b0;
-            jump = 1'b0;
+        else if (~op[3]) begin // jalr
+          second_add_source = 2'b10;
+          imm_source = 3'b000;
         end
-        // B-type
-        OPCODE_B_TYPE : begin
-            reg_write = 1'b0;
-            imm_source = 3'b010;
-            alu_source = 1'b0;
-            mem_write = 1'b0;
-            alu_op = 2'b01;
-            branch = 1'b1;
-            jump = 1'b0;
-            second_add_source = 2'b00;
-        end
-        // J-type + JALR weird Hybrib
-        OPCODE_J_TYPE, OPCODE_J_TYPE_JALR : begin
-            reg_write = 1'b1;
-            imm_source = 3'b011;
-            mem_write = 1'b0;
-            write_back_source = 2'b10; //pc_+4
-            branch = 1'b0;
-            jump = 1'b1;
-            if(op[3]) begin// jal
-                second_add_source = 2'b00;
-                imm_source = 3'b011;
-            end
-            else if (~op[3]) begin // jalr
-                second_add_source = 2'b10;
-                imm_source = 3'b000;
-            end
-        end
-        // U-type
-        OPCODE_U_TYPE_LUI, OPCODE_U_TYPE_AUIPC : begin
-            imm_source = 3'b100;
-            mem_write = 1'b0;
-            reg_write = 1'b1;
-            write_back_source = 2'b11;
-            branch = 1'b0;
-            jump = 1'b0;
-            case(op[5])
-                1'b1 : second_add_source = 2'b01; // lui
-                1'b0 : second_add_source = 2'b00; // auipc
-            endcase
-        end
-        // EVERYTHING ELSE
-        default: begin
-            // Don't touch the CPU nor MEMORY state
-            reg_write = 1'b0;
-            mem_write = 1'b0;
-            jump = 1'b0;
-            branch = 1'b0;
-            $display("Unknown/Unsupported OP CODE !");
-        end
+      end
+      // U-type
+      OPCODE_U_TYPE_LUI, OPCODE_U_TYPE_AUIPC: begin
+        imm_source = 3'b100;
+        mem_write = 1'b0;
+        reg_write = 1'b1;
+        write_back_source = 2'b11;
+        branch = 1'b0;
+        jump = 1'b0;
+        case(op[5])
+          1'b1: second_add_source = 2'b01; // lui
+          1'b0: second_add_source = 2'b00; // auipc
+        endcase
+      end
+      // EVERYTHING ELSE
+      default: begin
+        // Don't touch the CPU nor MEMORY state
+        reg_write = 1'b0;
+        mem_write = 1'b0;
+        jump = 1'b0;
+        branch = 1'b0;
+        $display("Unknown/unsupported opcode!");
+      end
     endcase
-end
+  end
 
-/**
-* ALU DECODER
-*/
+  /**
+  * ALU DECODER
+  */
 
-always_comb begin
+  always_comb begin
     case (alu_op)
-        // LW, SW
-        ALU_OP_LOAD_STORE : alu_control = ALU_ADD;
-        // R-Types, I-types
-        ALU_OP_MATH : begin
-            case (func3)
-                // ADD (and later SUB with a different F7)
-                F3_ADD_SUB : begin
-                    // 2 scenarios here :
-                    // - R-TYPE : either add or sub and we need to a check for that
-                    // - I-Type : aadi -> we use add arithmetic
-                    if(op == 7'b0110011) begin // R-type
-                        alu_control = (func7 == F7_SUB)? ALU_SUB : ALU_ADD;
-                    end else begin // I-Type
-                        alu_control = ALU_ADD;
-                    end
-                end
-                // AND
-                F3_AND : alu_control = ALU_AND;
-                // OR
-                F3_OR : alu_control = ALU_OR;
-                // SLT, SLTI
-                F3_SLT: alu_control = ALU_SLT;
-                // SLTU, SLTIU
-                F3_SLTU : alu_control = ALU_SLTU;
-                // XOR
-                F3_XOR : alu_control = ALU_XOR;
-                // SLL
-                F3_SLL : alu_control = ALU_SLL;
-                // SRL, SRA
-                F3_SRL_SRA : begin
-                    if(func7 == F7_SLL_SRL) begin
-                        alu_control = ALU_SRL; // srl
-                    end else if (func7 == F7_SRA) begin
-                        alu_control = ALU_SRA; // sra
-                    end
-                end
-            endcase
-        end
-        // BRANCHES
-        ALU_OP_BRANCHES : begin
-            case (func3)
-                // BEQ, BNE
-                F3_BEQ, F3_BNE : alu_control = 4'b0001;
-                // BLT, BGE
-                F3_BLT, F3_BGE : alu_control = 4'b0101;
-                // BLTU, BGEU
-                F3_BLTU, F3_BGEU : alu_control = 4'b0111;
-                default : alu_control = 4'b1111;
-            endcase
-        end
-        default : alu_control = 4'b1111;
+      // LW, SW
+      ALU_OP_LOAD_STORE: alu_control = ALU_ADD;
+      // R-Types, I-types
+      ALU_OP_MATH: begin
+        case (func3)
+          // ADD (and later SUB with a different F7)
+          F3_ADD_SUB: begin
+            // 2 scenarios here:
+            // - R-TYPE: either add or sub and we need to a check for that
+            // - I-Type: aadi -> we use add arithmetic
+            if(op == 7'b0110011) begin // R-type
+                alu_control = (func7 == F7_SUB)? ALU_SUB: ALU_ADD;
+            end else begin // I-Type
+                alu_control = ALU_ADD;
+            end
+          end
+          // AND
+          F3_AND: alu_control = ALU_AND;
+          // OR
+          F3_OR: alu_control = ALU_OR;
+          // SLT, SLTI
+          F3_SLT: alu_control = ALU_SLT;
+          // SLTU, SLTIU
+          F3_SLTU: alu_control = ALU_SLTU;
+          // XOR
+          F3_XOR: alu_control = ALU_XOR;
+          // SLL
+          F3_SLL: alu_control = ALU_SLL;
+          // SRL, SRA
+          F3_SRL_SRA: begin
+            if(func7 == F7_SLL_SRL) begin
+              alu_control = ALU_SRL; // srl
+            end else if (func7 == F7_SRA) begin
+              alu_control = ALU_SRA; // sra
+            end
+          end
+        endcase
+      end
+      // BRANCHES
+      ALU_OP_BRANCHES: begin
+        case (func3)
+          // BEQ, BNE
+          F3_BEQ, F3_BNE: alu_control = 4'b0001;
+          // BLT, BGE
+          F3_BLT, F3_BGE: alu_control = 4'b0101;
+          // BLTU, BGEU
+          F3_BLTU, F3_BGEU: alu_control = 4'b0111;
+          default: alu_control = 4'b1111;
+        endcase
+      end
+      default: alu_control = 4'b1111;
     endcase
-end
+  end
 
-/**
-* PC_Source
-*/
+  /**
+  * PC_Source
+  */
 
-logic assert_branch;
+  logic assert_branch;
 
-always_comb begin : branch_logic_decode
+  always_comb begin: branch_logic_decode
     case (func3)
-        // BEQ
-        F3_BEQ : assert_branch = alu_zero & branch;
-        // BLT, BLTU
-        F3_BLT, F3_BLTU : assert_branch = alu_last_bit & branch;
-        // BNE
-        F3_BNE : assert_branch = ~alu_zero & branch;
-        // BGE, BGEU
-        F3_BGE, F3_BGEU : assert_branch = ~alu_last_bit & branch;
-        default : assert_branch = 1'b0;
+      // BEQ
+      F3_BEQ: assert_branch = alu_zero & branch;
+      // BLT, BLTU
+      F3_BLT, F3_BLTU: assert_branch = alu_last_bit & branch;
+      // BNE
+      F3_BNE: assert_branch = ~alu_zero & branch;
+      // BGE, BGEU
+      F3_BGE, F3_BGEU: assert_branch = ~alu_last_bit & branch;
+      default: assert_branch = 1'b0;
     endcase
-end
+  end
 
-assign pc_source = assert_branch | jump;
-    
-endmodule
+  assign pc_source = assert_branch | jump;
+
+endmodule : control

--- a/0_single_cycle_edition/src/cpu.sv
+++ b/0_single_cycle_edition/src/cpu.sv
@@ -11,248 +11,250 @@
 `timescale 1ns/1ps
 
 module cpu (
-  input logic clk,
-  input logic rst_n
+    input logic clk,
+    input logic rst_n
 );
 
-  /**
-  * PROGRAM COUNTER
-  */
+    /**
+    * PROGRAM COUNTER
+    */
 
-  reg   [31:0] pc;
-  logic [31:0] pc_next;
-  logic [31:0] pc_plus_second_add;
-  logic [31:0] pc_plus_four;
-  assign pc_plus_four = pc + 4;
+    reg   [31:0] pc;
+    logic [31:0] pc_next;
+    logic [31:0] pc_plus_second_add;
+    logic [31:0] pc_plus_four;
+    assign pc_plus_four = pc + 4;
 
-  always_comb begin : pc_select
-    case (pc_source)
-      1'b0: pc_next = pc_plus_four; // pc + 4
-      1'b1: pc_next = pc_plus_second_add;
-    endcase
-  end : pc_select
+    always_comb begin : pc_select
+        case (pc_source)
+            1'b0: pc_next = pc_plus_four; // pc + 4
+            1'b1: pc_next = pc_plus_second_add;
+            default: ;
+        endcase
+    end : pc_select
 
-  always_comb begin : second_add_select
-    case (second_add_source)
-      2'b00: pc_plus_second_add = pc + immediate;
-      2'b01: pc_plus_second_add = immediate;
-      2'b10: pc_plus_second_add = read_reg1 + immediate;
-      default: pc_plus_second_add = 32'd0;
-    endcase
-  end : second_add_select
+    always_comb begin : second_add_select
+        case (second_add_source)
+            2'b00: pc_plus_second_add = pc + immediate;
+            2'b01: pc_plus_second_add = immediate;
+            2'b10: pc_plus_second_add = read_reg1 + immediate;
+            default: pc_plus_second_add = 32'd0;
+        endcase
+    end : second_add_select
 
-  always @(posedge clk) begin
-    if(rst_n == 0) begin
-      pc <= 32'b0;
-    end else begin
-      pc <= pc_next;
+    always @(posedge clk) begin
+        if(rst_n == 0) begin
+            pc <= 32'b0;
+        end else begin
+            pc <= pc_next;
+        end
     end
-  end
 
-  /**
-  * INSTRUCTION MEMORY
-  */
+    /**
+    * INSTRUCTION MEMORY
+    */
 
-  // Acts as a ROM.
-  wire [31:0] instruction;
+    // Acts as a ROM.
+    wire [31:0] instruction;
 
-  memory #(
-    .mem_init    ("./test_imemory.hex")
-  ) instruction_memory (
-    // Memory inputs
-    .clk(clk),
-    .address     (pc),
-    .write_data  (32'b0),
-    .write_enable(1'b0),
-    .rst_n       (1'b1),
-    .byte_enable (4'b0000),
+    memory #(
+        .mem_init    ("./test_imemory.hex")
+    ) instruction_memory (
+        // Memory inputs
+        .clk(clk),
+        .address     (pc),
+        .write_data  (32'b0),
+        .write_enable(1'b0),
+        .rst_n       (1'b1),
+        .byte_enable (4'b0000),
 
-    // Memory outputs
-    .read_data   (instruction)
-  );
+        // Memory outputs
+        .read_data   (instruction)
+    );
 
-  /**
-  * CONTROL
-  */
+    /**
+    * CONTROL
+    */
 
-  // Intercepts instructions data, generate control signals accordignly
-  // in control unit
-  logic [6:0] op;
-  assign op = instruction[6:0];
-  logic [2:0] f3;
-  assign f3 = instruction[14:12];
-  logic [6:0] f7;
-  assign f7 = instruction[31:25];
-  wire alu_zero;
-  wire alu_last_bit;
-  // out of control unit
-  wire  [3:0] alu_control;
-  wire  [2:0] imm_source;
-  wire mem_write;
-  wire reg_write;
-  // out muxes wires
-  wire alu_source;
-  wire  [1:0] write_back_source;
-  wire pc_source;
-  wire  [1:0] second_add_source;
+    // Intercepts instructions data, generate control signals accordignly
+    // in control unit
+    logic [6:0] op;
+    assign op = instruction[6:0];
+    logic [2:0] f3;
+    assign f3 = instruction[14:12];
+    logic [6:0] f7;
+    assign f7 = instruction[31:25];
+    wire alu_zero;
+    wire alu_last_bit;
+    // out of control unit
+    wire  [3:0] alu_control;
+    wire  [2:0] imm_source;
+    wire mem_write;
+    wire reg_write;
+    // out muxes wires
+    wire alu_source;
+    wire  [1:0] write_back_source;
+    wire pc_source;
+    wire  [1:0] second_add_source;
 
-  control control_unit(
-    .op               (op),
-    .func3            (f3),
-    .func7            (f7), // we still don't use f7 (YET)
-    .alu_zero         (alu_zero),
-    .alu_last_bit     (alu_last_bit),
+    control control_unit(
+        .op               (op),
+        .func3            (f3),
+        .func7            (f7), // we still don't use f7 (YET)
+        .alu_zero         (alu_zero),
+        .alu_last_bit     (alu_last_bit),
 
-    // OUT
-    .alu_control      (alu_control),
-    .imm_source       (imm_source),
-    .mem_write        (mem_write),
-    .reg_write        (reg_write),
-    // muxes out
-    .alu_source(alu_source),
-    .write_back_source(write_back_source),
-    .pc_source        (pc_source),
-    .second_add_source(second_add_source)
-  );
+        // OUT
+        .alu_control      (alu_control),
+        .imm_source       (imm_source),
+        .mem_write        (mem_write),
+        .reg_write        (reg_write),
+        // muxes out
+        .alu_source(alu_source),
+        .write_back_source(write_back_source),
+        .pc_source        (pc_source),
+        .second_add_source(second_add_source)
+    );
 
-  /**
-  * REGFILE
-  */
+    /**
+    * REGFILE
+    */
 
-  logic [4:0]  source_reg1;
-  assign source_reg1 = instruction[19:15];
-  logic [4:0]  source_reg2;
-  assign source_reg2 = instruction[24:20];
-  logic [4:0]  dest_reg;
-  assign dest_reg = instruction[11:7];
-  wire  [31:0] read_reg1;
-  wire  [31:0] read_reg2;
-  logic wb_valid;
+    logic [4:0]  source_reg1;
+    assign source_reg1 = instruction[19:15];
+    logic [4:0]  source_reg2;
+    assign source_reg2 = instruction[24:20];
+    logic [4:0]  dest_reg;
+    assign dest_reg = instruction[11:7];
+    wire  [31:0] read_reg1;
+    wire  [31:0] read_reg2;
+    logic wb_valid;
 
-  logic [31:0] write_back_data;
-  always_comb begin : write_back_source_select
-    case (write_back_source)
-      2'b00: begin
-        write_back_data = alu_result;
-        wb_valid = 1'b1;
-      end
-      2'b01: begin
-        write_back_data = mem_read_write_back_data;
-        wb_valid = mem_read_write_back_valid;
-      end
-      2'b10: begin
-        write_back_data = pc_plus_four;
-        wb_valid = 1'b1;
-      end
-      2'b11: begin
-        write_back_data = pc_plus_second_add;
-        wb_valid = 1'b1;
-      end
-    endcase
-  end : write_back_source_select
+    logic [31:0] write_back_data;
+    always_comb begin : write_back_source_select
+        case (write_back_source)
+            2'b00: begin
+                write_back_data = alu_result;
+                wb_valid = 1'b1;
+            end
+            2'b01: begin
+                write_back_data = mem_read_write_back_data;
+                wb_valid = mem_read_write_back_valid;
+            end
+            2'b10: begin
+                write_back_data = pc_plus_four;
+                wb_valid = 1'b1;
+            end
+            2'b11: begin
+                write_back_data = pc_plus_second_add;
+                wb_valid = 1'b1;
+            end
+            default: ;
+        endcase
+    end : write_back_source_select
 
-  regfile regfile(
-    // basic signals
-    .clk         (clk),
-    .rst_n       (rst_n),
+    regfile regfile(
+        // basic signals
+        .clk         (clk),
+        .rst_n       (rst_n),
 
-    // Read In
-    .address1    (source_reg1),
-    .address2    (source_reg2),
-    // Read out
-    .read_data1  (read_reg1),
-    .read_data2  (read_reg2),
+        // Read In
+        .address1    (source_reg1),
+        .address2    (source_reg2),
+        // Read out
+        .read_data1  (read_reg1),
+        .read_data2  (read_reg2),
 
-    // Write In
-    .write_enable(reg_write & wb_valid),
-    .write_data  (write_back_data),
-    .address3    (dest_reg)
-  );
+        // Write In
+        .write_enable(reg_write & wb_valid),
+        .write_data  (write_back_data),
+        .address3    (dest_reg)
+    );
 
-  /**
-  * SIGN EXTEND
-  */
-  logic [24:0] raw_imm;
-  assign raw_imm = instruction[31:7];
-  wire  [31:0] immediate;
+    /**
+    * SIGN EXTEND
+    */
+    logic [24:0] raw_imm;
+    assign raw_imm = instruction[31:7];
+    wire  [31:0] immediate;
 
-  signext sign_extender(
-    .raw_src   (raw_imm),
-    .imm_source(imm_source),
-    .immediate (immediate)
-  );
+    signext sign_extender(
+        .raw_src   (raw_imm),
+        .imm_source(imm_source),
+        .immediate (immediate)
+    );
 
-  /**
-  * ALU
-  */
-  wire  [31:0] alu_result;
-  logic [31:0] alu_src2;
+    /**
+    * ALU
+    */
+    wire  [31:0] alu_result;
+    logic [31:0] alu_src2;
 
-  always_comb begin : alu_source_select
-    case (alu_source)
-      1'b1: alu_src2 = immediate;
-      default: alu_src2 = read_reg2;
-    endcase
-  end : alu_source_select
+    always_comb begin : alu_source_select
+        case (alu_source)
+            1'b1: alu_src2 = immediate;
+            default: alu_src2 = read_reg2;
+        endcase
+    end : alu_source_select
 
-  alu alu_inst(
-    .alu_control(alu_control),
-    .src1       (read_reg1),
-    .src2       (alu_src2),
-    .alu_result (alu_result),
-    .zero       (alu_zero),
-    .last_bit   (alu_last_bit)
-  );
+    alu alu_inst(
+        .alu_control(alu_control),
+        .src1       (read_reg1),
+        .src2       (alu_src2),
+        .alu_result (alu_result),
+        .zero       (alu_zero),
+        .last_bit   (alu_last_bit)
+    );
 
-  /**
-  * LOAD/STORE DECODER
-  */
+    /**
+    * LOAD/STORE DECODER
+    */
 
-  wire [3:0]  mem_byte_enable;
-  wire [31:0] mem_write_data;
+    wire [3:0]  mem_byte_enable;
+    wire [31:0] mem_write_data;
 
-  load_store_decoder ls_decode(
-    .alu_result_address(alu_result),
-    .reg_read          (read_reg2),
-    .f3                (f3),
-    .byte_enable       (mem_byte_enable),
-    .data              (mem_write_data)
-  );
+    load_store_decoder ls_decode(
+        .alu_result_address(alu_result),
+        .reg_read          (read_reg2),
+        .f3                (f3),
+        .byte_enable       (mem_byte_enable),
+        .data              (mem_write_data)
+    );
 
 
-  /**
-  * DATA MEMORY
-  */
-  wire [31:0] mem_read;
+    /**
+    * DATA MEMORY
+    */
+    wire [31:0] mem_read;
 
-  memory #(
-    .mem_init    ("./test_dmemory.hex")
-  ) data_memory (
-    // Memory inputs
-    .clk(clk),
-    .address     ({alu_result[31:2], 2'b00}),
-    .write_data  (mem_write_data),
-    .write_enable(mem_write),
-    .byte_enable (mem_byte_enable),
-    .rst_n       (1'b1),
+    memory #(
+        .mem_init    ("./test_dmemory.hex")
+    ) data_memory (
+        // Memory inputs
+        .clk(clk),
+        .address     ({alu_result[31:2], 2'b00}),
+        .write_data  (mem_write_data),
+        .write_enable(mem_write),
+        .byte_enable (mem_byte_enable),
+        .rst_n       (1'b1),
 
-    // Memory outputs
-    .read_data   (mem_read)
-  );
+        // Memory outputs
+        .read_data   (mem_read)
+    );
 
-  /**
-  * READER
-  */
+    /**
+    * READER
+    */
 
-  wire [31:0] mem_read_write_back_data;
-  wire        mem_read_write_back_valid;
+    wire [31:0] mem_read_write_back_data;
+    wire        mem_read_write_back_valid;
 
-  reader reader_inst(
-    .mem_data(mem_read),
-    .be_mask (mem_byte_enable),
-    .f3      (f3),
-    .wb_data (mem_read_write_back_data),
-    .valid   (mem_read_write_back_valid)
-  );
+    reader reader_inst(
+        .mem_data(mem_read),
+        .be_mask (mem_byte_enable),
+        .f3      (f3),
+        .wb_data (mem_read_write_back_data),
+        .valid   (mem_read_write_back_valid)
+    );
 
 endmodule : cpu

--- a/0_single_cycle_edition/src/cpu.sv
+++ b/0_single_cycle_edition/src/cpu.sv
@@ -11,248 +11,248 @@
 `timescale 1ns/1ps
 
 module cpu (
-    input logic clk,
-    input logic rst_n
+  input logic clk,
+  input logic rst_n
 );
 
-/**
-* PROGRAM COUNTER
-*/
+  /**
+  * PROGRAM COUNTER
+  */
 
-reg [31:0] pc;
-logic [31:0] pc_next;
-logic [31:0] pc_plus_second_add;
-logic [31:0] pc_plus_four;
-assign pc_plus_four = pc + 4;
+  reg   [31:0] pc;
+  logic [31:0] pc_next;
+  logic [31:0] pc_plus_second_add;
+  logic [31:0] pc_plus_four;
+  assign pc_plus_four = pc + 4;
 
-always_comb begin : pc_select
+  always_comb begin : pc_select
     case (pc_source)
-        1'b0 : pc_next = pc_plus_four; // pc + 4
-        1'b1 : pc_next = pc_plus_second_add;
+      1'b0: pc_next = pc_plus_four; // pc + 4
+      1'b1: pc_next = pc_plus_second_add;
     endcase
-end
+  end : pc_select
 
-always_comb begin : second_add_select
+  always_comb begin : second_add_select
     case (second_add_source)
-        2'b00 : pc_plus_second_add = pc + immediate;
-        2'b01 : pc_plus_second_add = immediate;
-        2'b10 : pc_plus_second_add = read_reg1 + immediate;
-        default : pc_plus_second_add = 32'd0;
+      2'b00: pc_plus_second_add = pc + immediate;
+      2'b01: pc_plus_second_add = immediate;
+      2'b10: pc_plus_second_add = read_reg1 + immediate;
+      default: pc_plus_second_add = 32'd0;
     endcase
-end
+  end : second_add_select
 
-always @(posedge clk) begin
+  always @(posedge clk) begin
     if(rst_n == 0) begin
-        pc <= 32'b0;
+      pc <= 32'b0;
     end else begin
-        pc <= pc_next;
+      pc <= pc_next;
     end
-end
+  end
 
-/**
-* INSTRUCTION MEMORY
-*/
+  /**
+  * INSTRUCTION MEMORY
+  */
 
-// Acts as a ROM.
-wire [31:0] instruction;
+  // Acts as a ROM.
+  wire [31:0] instruction;
 
-memory #(
-    .mem_init("./test_imemory.hex")
-) instruction_memory (
+  memory #(
+    .mem_init    ("./test_imemory.hex")
+  ) instruction_memory (
     // Memory inputs
     .clk(clk),
-    .address(pc),
-    .write_data(32'b0),
+    .address     (pc),
+    .write_data  (32'b0),
     .write_enable(1'b0),
-    .rst_n(1'b1),
-    .byte_enable(4'b0000),
+    .rst_n       (1'b1),
+    .byte_enable (4'b0000),
 
     // Memory outputs
-    .read_data(instruction)
-);
+    .read_data   (instruction)
+  );
 
-/**
-* CONTROL
-*/
+  /**
+  * CONTROL
+  */
 
-// Intercepts instructions data, generate control signals accordignly
-// in control unit
-logic [6:0] op;
-assign op = instruction[6:0];
-logic [2:0] f3;
-assign f3 = instruction[14:12];
-logic [6:0] f7;
-assign f7 = instruction[31:25];
-wire alu_zero;
-wire alu_last_bit;
-// out of control unit
-wire [3:0] alu_control;
-wire [2:0] imm_source;
-wire mem_write;
-wire reg_write;
-// out muxes wires
-wire alu_source;
-wire [1:0] write_back_source;
-wire pc_source;
-wire [1:0] second_add_source;
+  // Intercepts instructions data, generate control signals accordignly
+  // in control unit
+  logic [6:0] op;
+  assign op = instruction[6:0];
+  logic [2:0] f3;
+  assign f3 = instruction[14:12];
+  logic [6:0] f7;
+  assign f7 = instruction[31:25];
+  wire alu_zero;
+  wire alu_last_bit;
+  // out of control unit
+  wire  [3:0] alu_control;
+  wire  [2:0] imm_source;
+  wire mem_write;
+  wire reg_write;
+  // out muxes wires
+  wire alu_source;
+  wire  [1:0] write_back_source;
+  wire pc_source;
+  wire  [1:0] second_add_source;
 
-control control_unit(
-    .op(op),
-    .func3(f3),
-    .func7(f7), // we still don't use f7 (YET)
-    .alu_zero(alu_zero),
-    .alu_last_bit(alu_last_bit),
+  control control_unit(
+    .op               (op),
+    .func3            (f3),
+    .func7            (f7), // we still don't use f7 (YET)
+    .alu_zero         (alu_zero),
+    .alu_last_bit     (alu_last_bit),
 
     // OUT
-    .alu_control(alu_control),
-    .imm_source(imm_source),
-    .mem_write(mem_write),
-    .reg_write(reg_write),
+    .alu_control      (alu_control),
+    .imm_source       (imm_source),
+    .mem_write        (mem_write),
+    .reg_write        (reg_write),
     // muxes out
     .alu_source(alu_source),
     .write_back_source(write_back_source),
-    .pc_source(pc_source),
+    .pc_source        (pc_source),
     .second_add_source(second_add_source)
-);
+  );
 
-/**
-* REGFILE
-*/
+  /**
+  * REGFILE
+  */
 
-logic [4:0] source_reg1;
-assign source_reg1 = instruction[19:15];
-logic [4:0] source_reg2;
-assign source_reg2 = instruction[24:20];
-logic [4:0] dest_reg;
-assign dest_reg = instruction[11:7];
-wire [31:0] read_reg1;
-wire [31:0] read_reg2;
-logic wb_valid;
+  logic [4:0]  source_reg1;
+  assign source_reg1 = instruction[19:15];
+  logic [4:0]  source_reg2;
+  assign source_reg2 = instruction[24:20];
+  logic [4:0]  dest_reg;
+  assign dest_reg = instruction[11:7];
+  wire  [31:0] read_reg1;
+  wire  [31:0] read_reg2;
+  logic wb_valid;
 
-logic [31:0] write_back_data;
-always_comb begin : write_back_source_select
+  logic [31:0] write_back_data;
+  always_comb begin : write_back_source_select
     case (write_back_source)
-        2'b00: begin
-            write_back_data = alu_result;
-            wb_valid = 1'b1;
-        end
-        2'b01: begin
-            write_back_data = mem_read_write_back_data;
-            wb_valid = mem_read_write_back_valid;
-        end
-        2'b10: begin
-            write_back_data = pc_plus_four;
-            wb_valid = 1'b1;
-        end
-        2'b11: begin
-            write_back_data = pc_plus_second_add;
-            wb_valid = 1'b1;
-        end
+      2'b00: begin
+        write_back_data = alu_result;
+        wb_valid = 1'b1;
+      end
+      2'b01: begin
+        write_back_data = mem_read_write_back_data;
+        wb_valid = mem_read_write_back_valid;
+      end
+      2'b10: begin
+        write_back_data = pc_plus_four;
+        wb_valid = 1'b1;
+      end
+      2'b11: begin
+        write_back_data = pc_plus_second_add;
+        wb_valid = 1'b1;
+      end
     endcase
-end
+  end : write_back_source_select
 
-regfile regfile(
+  regfile regfile(
     // basic signals
-    .clk(clk),
-    .rst_n(rst_n),
+    .clk         (clk),
+    .rst_n       (rst_n),
 
     // Read In
-    .address1(source_reg1),
-    .address2(source_reg2),
+    .address1    (source_reg1),
+    .address2    (source_reg2),
     // Read out
-    .read_data1(read_reg1),
-    .read_data2(read_reg2),
+    .read_data1  (read_reg1),
+    .read_data2  (read_reg2),
 
     // Write In
     .write_enable(reg_write & wb_valid),
-    .write_data(write_back_data),
-    .address3(dest_reg)
-);
+    .write_data  (write_back_data),
+    .address3    (dest_reg)
+  );
 
-/**
-* SIGN EXTEND
-*/
-logic [24:0] raw_imm;
-assign raw_imm = instruction[31:7];
-wire [31:0] immediate;
+  /**
+  * SIGN EXTEND
+  */
+  logic [24:0] raw_imm;
+  assign raw_imm = instruction[31:7];
+  wire  [31:0] immediate;
 
-signext sign_extender(
-    .raw_src(raw_imm),
+  signext sign_extender(
+    .raw_src   (raw_imm),
     .imm_source(imm_source),
-    .immediate(immediate)
-);
+    .immediate (immediate)
+  );
 
-/**
-* ALU
-*/
-wire [31:0] alu_result;
-logic [31:0] alu_src2;
+  /**
+  * ALU
+  */
+  wire  [31:0] alu_result;
+  logic [31:0] alu_src2;
 
-always_comb begin : alu_source_select
+  always_comb begin : alu_source_select
     case (alu_source)
-        1'b1: alu_src2 = immediate;
-        default: alu_src2 = read_reg2;
+      1'b1: alu_src2 = immediate;
+      default: alu_src2 = read_reg2;
     endcase
-end
+  end : alu_source_select
 
-alu alu_inst(
+  alu alu_inst(
     .alu_control(alu_control),
-    .src1(read_reg1),
-    .src2(alu_src2),
-    .alu_result(alu_result),
-    .zero(alu_zero),
-    .last_bit(alu_last_bit)
-);
+    .src1       (read_reg1),
+    .src2       (alu_src2),
+    .alu_result (alu_result),
+    .zero       (alu_zero),
+    .last_bit   (alu_last_bit)
+  );
 
-/**
-* LOAD/STORE DECODER
-*/
+  /**
+  * LOAD/STORE DECODER
+  */
 
-wire [3:0] mem_byte_enable;
-wire [31:0] mem_write_data;
+  wire [3:0]  mem_byte_enable;
+  wire [31:0] mem_write_data;
 
-load_store_decoder ls_decode(
+  load_store_decoder ls_decode(
     .alu_result_address(alu_result),
-    .reg_read(read_reg2),
-    .f3(f3),
-    .byte_enable(mem_byte_enable),
-    .data(mem_write_data)
-);
+    .reg_read          (read_reg2),
+    .f3                (f3),
+    .byte_enable       (mem_byte_enable),
+    .data              (mem_write_data)
+  );
 
 
-/**
-* DATA MEMORY
-*/
-wire [31:0] mem_read;
+  /**
+  * DATA MEMORY
+  */
+  wire [31:0] mem_read;
 
-memory #(
-    .mem_init("./test_dmemory.hex")
-) data_memory (
+  memory #(
+    .mem_init    ("./test_dmemory.hex")
+  ) data_memory (
     // Memory inputs
     .clk(clk),
-    .address({alu_result[31:2], 2'b00}),
-    .write_data(mem_write_data),
+    .address     ({alu_result[31:2], 2'b00}),
+    .write_data  (mem_write_data),
     .write_enable(mem_write),
-    .byte_enable(mem_byte_enable),
-    .rst_n(1'b1),
+    .byte_enable (mem_byte_enable),
+    .rst_n       (1'b1),
 
     // Memory outputs
-    .read_data(mem_read)
-);
+    .read_data   (mem_read)
+  );
 
-/**
-* READER
-*/
+  /**
+  * READER
+  */
 
-wire [31:0] mem_read_write_back_data;
-wire mem_read_write_back_valid;
+  wire [31:0] mem_read_write_back_data;
+  wire        mem_read_write_back_valid;
 
-reader reader_inst(
+  reader reader_inst(
     .mem_data(mem_read),
-    .be_mask(mem_byte_enable),
-    .f3(f3),
-    .wb_data(mem_read_write_back_data),
-    .valid(mem_read_write_back_valid)
-);
-    
-endmodule
+    .be_mask (mem_byte_enable),
+    .f3      (f3),
+    .wb_data (mem_read_write_back_data),
+    .valid   (mem_read_write_back_valid)
+  );
+
+endmodule : cpu

--- a/0_single_cycle_edition/src/load_store_decoder.sv
+++ b/0_single_cycle_edition/src/load_store_decoder.sv
@@ -9,65 +9,63 @@
 `timescale 1ns/1ps
 
 module load_store_decoder (
-  input  logic [31:0] alu_result_address,
-  input  logic [2:0]  f3,
-  input  logic [31:0] reg_read,
-  output logic [3:0]  byte_enable,
-  output logic [31:0] data
+    input  logic [31:0] alu_result_address,
+    input  logic [2:0]  f3,
+    input  logic [31:0] reg_read,
+    output logic [3:0]  byte_enable,
+    output logic [31:0] data
 );
 
-  import holy_core_pkg::*;
+    import holy_core_pkg::*;
 
-  logic [1:0] offset;
-  assign offset = alu_result_address[1:0];
+    logic [1:0] offset;
+    assign offset = alu_result_address[1:0];
 
-  always_comb begin
-    case (f3)
-      F3_BYTE, F3_BYTE_U : begin // SB, LB, LBU
-        case (offset)
-          2'b00: begin
-            byte_enable = 4'b0001;
-            data = (reg_read & 32'h000000FF);
-          end
-          2'b01: begin 
-            byte_enable = 4'b0010;
-            data = (reg_read & 32'h000000FF) << 8;
-          end
-          2'b10: begin 
-            byte_enable = 4'b0100;
-            data = (reg_read & 32'h000000FF) << 16;
-          end
-          2'b11: begin 
-            byte_enable = 4'b1000;
-            data = (reg_read & 32'h000000FF) << 24;
-          end
-          default: byte_enable = 4'b0000;
+    always_comb begin
+        case (f3)
+            F3_BYTE, F3_BYTE_U : begin // SB, LB, LBU
+                case (offset)
+                    2'b00: begin
+                        byte_enable = 4'b0001;
+                        data = (reg_read & 32'h000000FF);
+                    end
+                    2'b01: begin
+                        byte_enable = 4'b0010;
+                        data = (reg_read & 32'h000000FF) << 8;
+                    end
+                    2'b10: begin
+                        byte_enable = 4'b0100;
+                        data = (reg_read & 32'h000000FF) << 16;
+                    end
+                    2'b11: begin
+                        byte_enable = 4'b1000;
+                        data = (reg_read & 32'h000000FF) << 24;
+                    end
+                    default: byte_enable = 4'b0000;
+                endcase
+            end
+
+            F3_WORD: begin // SW
+                byte_enable = (offset == 2'b00) ? 4'b1111 : 4'b0000;
+                data = reg_read;
+            end
+
+            F3_HALFWORD, F3_HALFWORD_U : begin // SH, LH, LHU
+                case (offset)
+                    2'b00: begin
+                        byte_enable = 4'b0011;
+                        data = (reg_read & 32'h0000FFFF);
+                    end
+                    2'b10: begin
+                        byte_enable = 4'b1100;
+                        data = (reg_read & 32'h0000FFFF) << 16;
+                    end
+                    default: byte_enable = 4'b0000;
+                endcase
+            end
+
+            default: byte_enable = 4'b0000; // No operation for unsupported types
         endcase
-      end
-
-      F3_WORD: begin // SW
-        byte_enable = (offset == 2'b00) ? 4'b1111 : 4'b0000;
-        data = reg_read;
-      end
-
-      F3_HALFWORD, F3_HALFWORD_U : begin // SH, LH, LHU
-        case (offset)
-          2'b00: begin 
-            byte_enable = 4'b0011;
-            data = (reg_read & 32'h0000FFFF);
-          end
-          2'b10: begin
-            byte_enable = 4'b1100;
-            data = (reg_read & 32'h0000FFFF) << 16;
-          end
-          default: byte_enable = 4'b0000;
-        endcase
-      end
-
-      default: begin
-        byte_enable = 4'b0000; // No operation for unsupported types
-      end
-    endcase
-  end
+    end
 
 endmodule : load_store_decoder

--- a/0_single_cycle_edition/src/load_store_decoder.sv
+++ b/0_single_cycle_edition/src/load_store_decoder.sv
@@ -9,66 +9,65 @@
 `timescale 1ns/1ps
 
 module load_store_decoder (
-    input  logic [31:0] alu_result_address,
-    input  logic [2:0]  f3,
-    input  logic [31:0] reg_read,
-    output logic [3:0]  byte_enable,
-    output logic [31:0] data
+  input  logic [31:0] alu_result_address,
+  input  logic [2:0]  f3,
+  input  logic [31:0] reg_read,
+  output logic [3:0]  byte_enable,
+  output logic [31:0] data
 );
 
-import holy_core_pkg::*;
+  import holy_core_pkg::*;
 
-logic [1:0] offset;
+  logic [1:0] offset;
+  assign offset = alu_result_address[1:0];
 
-assign offset = alu_result_address[1:0];
-
-always_comb begin
+  always_comb begin
     case (f3)
-        F3_BYTE, F3_BYTE_U : begin // SB, LB, LBU
-            case (offset)
-                2'b00: begin
-                    byte_enable = 4'b0001;
-                    data = (reg_read & 32'h000000FF);
-                end
-                2'b01: begin 
-                    byte_enable = 4'b0010;
-                    data = (reg_read & 32'h000000FF) << 8;
-                end
-                2'b10: begin 
-                    byte_enable = 4'b0100;
-                    data = (reg_read & 32'h000000FF) << 16;
-                end
-                2'b11: begin 
-                    byte_enable = 4'b1000;
-                    data = (reg_read & 32'h000000FF) << 24;
-                end
-                default: byte_enable = 4'b0000;
-            endcase
-        end
-        
-        F3_WORD: begin // SW
-            byte_enable = (offset == 2'b00) ? 4'b1111 : 4'b0000;
-            data = reg_read;
-        end
+      F3_BYTE, F3_BYTE_U : begin // SB, LB, LBU
+        case (offset)
+          2'b00: begin
+            byte_enable = 4'b0001;
+            data = (reg_read & 32'h000000FF);
+          end
+          2'b01: begin 
+            byte_enable = 4'b0010;
+            data = (reg_read & 32'h000000FF) << 8;
+          end
+          2'b10: begin 
+            byte_enable = 4'b0100;
+            data = (reg_read & 32'h000000FF) << 16;
+          end
+          2'b11: begin 
+            byte_enable = 4'b1000;
+            data = (reg_read & 32'h000000FF) << 24;
+          end
+          default: byte_enable = 4'b0000;
+        endcase
+      end
 
-        F3_HALFWORD, F3_HALFWORD_U : begin // SH, LH, LHU
-            case (offset)
-                2'b00: begin 
-                    byte_enable = 4'b0011;
-                    data = (reg_read & 32'h0000FFFF);
-                end
-                2'b10: begin
-                    byte_enable = 4'b1100;
-                    data = (reg_read & 32'h0000FFFF) << 16;
-                end
-                default: byte_enable = 4'b0000;
-            endcase
-        end
+      F3_WORD: begin // SW
+        byte_enable = (offset == 2'b00) ? 4'b1111 : 4'b0000;
+        data = reg_read;
+      end
 
-        default: begin
-            byte_enable = 4'b0000; // No operation for unsupported types
-        end
+      F3_HALFWORD, F3_HALFWORD_U : begin // SH, LH, LHU
+        case (offset)
+          2'b00: begin 
+            byte_enable = 4'b0011;
+            data = (reg_read & 32'h0000FFFF);
+          end
+          2'b10: begin
+            byte_enable = 4'b1100;
+            data = (reg_read & 32'h0000FFFF) << 16;
+          end
+          default: byte_enable = 4'b0000;
+        endcase
+      end
+
+      default: begin
+        byte_enable = 4'b0000; // No operation for unsupported types
+      end
     endcase
-end
+  end
 
-endmodule
+endmodule : load_store_decoder

--- a/0_single_cycle_edition/src/memory.sv
+++ b/0_single_cycle_edition/src/memory.sv
@@ -10,55 +10,55 @@
 `timescale 1ns/1ps
 
 module memory #(
-  parameter WORDS = 128,
-  parameter mem_init = ""
+    parameter WORDS = 128,
+    parameter mem_init = ""
 ) (
-  input  logic        clk,
-  input  logic [31:0] address,
-  input  logic [31:0] write_data,
-  input  logic [3:0]  byte_enable,
-  input  logic        write_enable,
-  input  logic        rst_n,
-  output logic [31:0] read_data
+    input  logic        clk,
+    input  logic [31:0] address,
+    input  logic [31:0] write_data,
+    input  logic [3:0]  byte_enable,
+    input  logic        write_enable,
+    input  logic        rst_n,
+    output logic [31:0] read_data
 );
 
-  // Memory array (32-bit words)
-  reg [31:0] mem [0:WORDS-1];
+    // Memory array (32-bit words)
+    reg [31:0] mem [0:WORDS-1];
 
-  initial begin
-    if (mem_init != "") begin
-      $readmemh(mem_init, mem);
-    end
-  end
-
-  // Write operation
-  always @(posedge clk) begin
-    if (rst_n == 1'b0) begin
-      for (int i = 0; i < WORDS; i++) begin
-        mem[i] <= 32'd0;
-      end
-    end else begin
-      if(write_enable) begin
-        if (address[1:0] != 2'b00) begin
-          $fatal("STOPPING SIMULATION: Misaligned write at address %h. HINT: Check your code.", address);
-        end else begin
-          // use byte-enable to selectively write bytes
-          for (int i = 0; i < 4; i++) begin
-            if (byte_enable[i]) begin
-              /* verilator lint_off WIDTHTRUNC */
-              mem[address[31:2]][(i*8)+:8] <= write_data[(i*8)+:8];
-              /* verilator lint_on WIDTHTRUNC */
-            end
-          end
+    initial begin
+        if (mem_init != "") begin
+            $readmemh(mem_init, mem);
         end
-      end
     end
-  end
 
-  always_comb begin
-    /* verilator lint_off WIDTHTRUNC */
-    read_data = mem[address[31:2]];
-    /* verilator lint_on WIDTHTRUNC */
-  end
+    // Write operation
+    always @(posedge clk) begin
+        if (rst_n == 1'b0) begin
+            for (int i = 0; i < WORDS; i++) begin
+                mem[i] <= 32'd0;
+            end
+        end else begin
+            if(write_enable) begin
+                if (address[1:0] != 2'b00) begin
+                    $fatal("STOPPING SIMULATION: Misaligned write at address %h. HINT: Check your code.", address);
+                end else begin
+                    // use byte-enable to selectively write bytes
+                    for (int i = 0; i < 4; i++) begin
+                        if (byte_enable[i]) begin
+                            /* verilator lint_off WIDTHTRUNC */
+                            mem[address[31:2]][(i*8)+:8] <= write_data[(i*8)+:8];
+                            /* verilator lint_on WIDTHTRUNC */
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    always_comb begin
+        /* verilator lint_off WIDTHTRUNC */
+        read_data = mem[address[31:2]];
+        /* verilator lint_on WIDTHTRUNC */
+    end
 
 endmodule : memory

--- a/0_single_cycle_edition/src/memory.sv
+++ b/0_single_cycle_edition/src/memory.sv
@@ -10,55 +10,55 @@
 `timescale 1ns/1ps
 
 module memory #(
-    parameter WORDS = 128,
-    parameter mem_init = ""
+  parameter WORDS = 128,
+  parameter mem_init = ""
 ) (
-    input  logic        clk,
-    input  logic [31:0] address,
-    input  logic [31:0] write_data,
-    input  logic [3:0]  byte_enable,
-    input  logic        write_enable,
-    input  logic        rst_n,
-    output logic [31:0] read_data
+  input  logic        clk,
+  input  logic [31:0] address,
+  input  logic [31:0] write_data,
+  input  logic [3:0]  byte_enable,
+  input  logic        write_enable,
+  input  logic        rst_n,
+  output logic [31:0] read_data
 );
 
-// Memory array (32-bit words)
-reg [31:0] mem [0:WORDS-1];
+  // Memory array (32-bit words)
+  reg [31:0] mem [0:WORDS-1];
 
-initial begin
+  initial begin
     if (mem_init != "") begin
-        $readmemh(mem_init, mem);
+      $readmemh(mem_init, mem);
     end
-end
+  end
 
-// Write operation
-always @(posedge clk) begin
+  // Write operation
+  always @(posedge clk) begin
     if (rst_n == 1'b0) begin
-        for (int i = 0; i < WORDS; i++) begin
-            mem[i] <= 32'd0;
-        end
+      for (int i = 0; i < WORDS; i++) begin
+        mem[i] <= 32'd0;
+      end
     end else begin
-        if(write_enable) begin
-            if (address[1:0] != 2'b00) begin
-                $fatal("STOPPING SIMULATION: Misaligned write at address %h. HINT: Check your code.", address);
-            end else begin
-                // use byte-enable to selectively write bytes
-                for (int i = 0; i < 4; i++) begin
-                    if (byte_enable[i]) begin
-                        /* verilator lint_off WIDTHTRUNC */
-                        mem[address[31:2]][(i*8)+:8] <= write_data[(i*8)+:8];
-                        /* verilator lint_on WIDTHTRUNC */
-                    end
-                end
+      if(write_enable) begin
+        if (address[1:0] != 2'b00) begin
+          $fatal("STOPPING SIMULATION: Misaligned write at address %h. HINT: Check your code.", address);
+        end else begin
+          // use byte-enable to selectively write bytes
+          for (int i = 0; i < 4; i++) begin
+            if (byte_enable[i]) begin
+              /* verilator lint_off WIDTHTRUNC */
+              mem[address[31:2]][(i*8)+:8] <= write_data[(i*8)+:8];
+              /* verilator lint_on WIDTHTRUNC */
             end
+          end
         end
+      end
     end
-end
+  end
 
-always_comb begin
+  always_comb begin
     /* verilator lint_off WIDTHTRUNC */
     read_data = mem[address[31:2]];
     /* verilator lint_on WIDTHTRUNC */
-end
+  end
 
-endmodule
+endmodule : memory

--- a/0_single_cycle_edition/src/reader.sv
+++ b/0_single_cycle_edition/src/reader.sv
@@ -10,73 +10,73 @@
 `timescale 1ns/1ps
 
 module reader (
-    input  logic [31:0] mem_data,
-    input  logic [3:0]  be_mask,
-    input  logic [2:0]  f3,
-    output logic [31:0] wb_data,
-    output logic        valid
+  input  logic [31:0] mem_data,
+  input  logic [3:0]  be_mask,
+  input  logic [2:0]  f3,
+  output logic [31:0] wb_data,
+  output logic        valid
 ); 
 
-import holy_core_pkg::*;
+  import holy_core_pkg::*;
 
-logic sign_extend;
-assign sign_extend = ~f3[2];
+  logic sign_extend;
+  assign sign_extend = ~f3[2];
 
-logic [31:0] masked_data; // just a mask applied
-logic [31:0] raw_data; // Data shifted according to instruction
-// and then mem_data is the final output with sign extension
+  logic [31:0] masked_data; // just a mask applied
+  logic [31:0] raw_data; // Data shifted according to instruction
+  // and then mem_data is the final output with sign extension
 
-always_comb begin : mask_apply
+  always_comb begin : mask_apply
     for (int i = 0; i < 4; i++) begin
-        if (be_mask[i]) begin
-            masked_data[(i*8)+:8] = mem_data[(i*8)+:8];
-        end else begin
-            masked_data[(i*8)+:8] = 8'h00;
-        end
+      if (be_mask[i]) begin
+        masked_data[(i*8)+:8] = mem_data[(i*8)+:8];
+      end else begin
+        masked_data[(i*8)+:8] = 8'h00;
+      end
     end
-end
+  end : mask_apply
 
-always_comb begin : shift_data
+  always_comb begin : shift_data
     case (f3)
-        F3_WORD : raw_data = masked_data; // masked data is full word in that case
+      F3_WORD: raw_data = masked_data; // masked data is full word in that case
 
-        F3_BYTE, F3_BYTE_U: begin // LB, LBU
-            case (be_mask)
-                4'b0001: raw_data = masked_data;
-                4'b0010: raw_data = masked_data >> 8;
-                4'b0100: raw_data = masked_data >> 16;
-                4'b1000: raw_data = masked_data >> 24;
-                default: raw_data = 32'd0;
-            endcase
-        end
+      F3_BYTE, F3_BYTE_U: begin // LB, LBU
+        case (be_mask)
+          4'b0001: raw_data = masked_data;
+          4'b0010: raw_data = masked_data >> 8;
+          4'b0100: raw_data = masked_data >> 16;
+          4'b1000: raw_data = masked_data >> 24;
+          default: raw_data = 32'd0;
+        endcase
+      end
 
-        F3_HALFWORD, F3_HALFWORD_U: begin // LH, LHU
-            case (be_mask)
-                4'b0011: raw_data = masked_data;
-                4'b1100: raw_data = masked_data >> 16;
-                default: raw_data = 32'd0;
-            endcase
-        end
+      F3_HALFWORD, F3_HALFWORD_U: begin // LH, LHU
+        case (be_mask)
+          4'b0011: raw_data = masked_data;
+          4'b1100: raw_data = masked_data >> 16;
+          default: raw_data = 32'd0;
+        endcase
+      end
 
-        default: raw_data = 32'd0;
+      default: raw_data = 32'd0;
     endcase
-end
+  end : shift_data
 
-always_comb begin : sign_extend_logic
+  always_comb begin : sign_extend_logic
     case (f3)
-        // LW
-        F3_WORD : wb_data = raw_data;
+      // LW
+      F3_WORD: wb_data = raw_data;
 
-        // LB, LBU
-        F3_BYTE, F3_BYTE_U: wb_data = sign_extend ? {{24{raw_data[7]}},raw_data[7:0]} : raw_data;
+      // LB, LBU
+      F3_BYTE, F3_BYTE_U: wb_data = sign_extend ? {{24{raw_data[7]}},raw_data[7:0]} : raw_data;
 
-        // LH, LHU
-        F3_HALFWORD, F3_HALFWORD_U: wb_data = sign_extend ? {{16{raw_data[15]}},raw_data[15:0]} : raw_data;
+      // LH, LHU
+      F3_HALFWORD, F3_HALFWORD_U: wb_data = sign_extend ? {{16{raw_data[15]}},raw_data[15:0]} : raw_data;
 
-        default: wb_data = 32'd0;
+      default: wb_data = 32'd0;
     endcase
 
     valid = |be_mask;
-end
-    
-endmodule
+  end : sign_extend_logic
+
+endmodule : reader

--- a/0_single_cycle_edition/src/reader.sv
+++ b/0_single_cycle_edition/src/reader.sv
@@ -10,73 +10,73 @@
 `timescale 1ns/1ps
 
 module reader (
-  input  logic [31:0] mem_data,
-  input  logic [3:0]  be_mask,
-  input  logic [2:0]  f3,
-  output logic [31:0] wb_data,
-  output logic        valid
-); 
+    input  logic [31:0] mem_data,
+    input  logic [3:0]  be_mask,
+    input  logic [2:0]  f3,
+    output logic [31:0] wb_data,
+    output logic        valid
+);
 
-  import holy_core_pkg::*;
+    import holy_core_pkg::*;
 
-  logic sign_extend;
-  assign sign_extend = ~f3[2];
+    logic sign_extend;
+    assign sign_extend = ~f3[2];
 
-  logic [31:0] masked_data; // just a mask applied
-  logic [31:0] raw_data; // Data shifted according to instruction
-  // and then mem_data is the final output with sign extension
+    logic [31:0] masked_data; // just a mask applied
+    logic [31:0] raw_data; // Data shifted according to instruction
+    // and then mem_data is the final output with sign extension
 
-  always_comb begin : mask_apply
-    for (int i = 0; i < 4; i++) begin
-      if (be_mask[i]) begin
-        masked_data[(i*8)+:8] = mem_data[(i*8)+:8];
-      end else begin
-        masked_data[(i*8)+:8] = 8'h00;
-      end
-    end
-  end : mask_apply
+    always_comb begin : mask_apply
+        for (int i = 0; i < 4; i++) begin
+            if (be_mask[i]) begin
+            masked_data[(i*8)+:8] = mem_data[(i*8)+:8];
+            end else begin
+            masked_data[(i*8)+:8] = 8'h00;
+            end
+        end
+    end : mask_apply
 
-  always_comb begin : shift_data
-    case (f3)
-      F3_WORD: raw_data = masked_data; // masked data is full word in that case
+    always_comb begin : shift_data
+        case (f3)
+            F3_WORD: raw_data = masked_data; // masked data is full word in that case
 
-      F3_BYTE, F3_BYTE_U: begin // LB, LBU
-        case (be_mask)
-          4'b0001: raw_data = masked_data;
-          4'b0010: raw_data = masked_data >> 8;
-          4'b0100: raw_data = masked_data >> 16;
-          4'b1000: raw_data = masked_data >> 24;
-          default: raw_data = 32'd0;
+            F3_BYTE, F3_BYTE_U: begin // LB, LBU
+                case (be_mask)
+                    4'b0001: raw_data = masked_data;
+                    4'b0010: raw_data = masked_data >> 8;
+                    4'b0100: raw_data = masked_data >> 16;
+                    4'b1000: raw_data = masked_data >> 24;
+                    default: raw_data = 32'd0;
+                endcase
+            end
+
+            F3_HALFWORD, F3_HALFWORD_U: begin // LH, LHU
+                case (be_mask)
+                    4'b0011: raw_data = masked_data;
+                    4'b1100: raw_data = masked_data >> 16;
+                    default: raw_data = 32'd0;
+                endcase
+            end
+
+            default: raw_data = 32'd0;
         endcase
-      end
+    end : shift_data
 
-      F3_HALFWORD, F3_HALFWORD_U: begin // LH, LHU
-        case (be_mask)
-          4'b0011: raw_data = masked_data;
-          4'b1100: raw_data = masked_data >> 16;
-          default: raw_data = 32'd0;
+    always_comb begin : sign_extend_logic
+        case (f3)
+            // LW
+            F3_WORD: wb_data = raw_data;
+
+            // LB, LBU
+            F3_BYTE, F3_BYTE_U: wb_data = sign_extend ? {{24{raw_data[7]}},raw_data[7:0]} : raw_data;
+
+            // LH, LHU
+            F3_HALFWORD, F3_HALFWORD_U: wb_data = sign_extend ? {{16{raw_data[15]}},raw_data[15:0]} : raw_data;
+
+            default: wb_data = 32'd0;
         endcase
-      end
 
-      default: raw_data = 32'd0;
-    endcase
-  end : shift_data
-
-  always_comb begin : sign_extend_logic
-    case (f3)
-      // LW
-      F3_WORD: wb_data = raw_data;
-
-      // LB, LBU
-      F3_BYTE, F3_BYTE_U: wb_data = sign_extend ? {{24{raw_data[7]}},raw_data[7:0]} : raw_data;
-
-      // LH, LHU
-      F3_HALFWORD, F3_HALFWORD_U: wb_data = sign_extend ? {{16{raw_data[15]}},raw_data[15:0]} : raw_data;
-
-      default: wb_data = 32'd0;
-    endcase
-
-    valid = |be_mask;
-  end : sign_extend_logic
+        valid = |be_mask;
+    end : sign_extend_logic
 
 endmodule : reader

--- a/0_single_cycle_edition/src/regfile.sv
+++ b/0_single_cycle_edition/src/regfile.sv
@@ -10,44 +10,44 @@
 
 module regfile (
 
-  // Basic signals
-  input  logic        clk,
-  input  logic        rst_n,
+    // Basic signals
+    input  logic        clk,
+    input  logic        rst_n,
 
-  // Reads
-  input  logic [4:0]  address1,
-  input  logic [4:0]  address2,
-  output logic [31:0] read_data1,
-  output logic [31:0] read_data2,
+    // Reads
+    input  logic [4:0]  address1,
+    input  logic [4:0]  address2,
+    output logic [31:0] read_data1,
+    output logic [31:0] read_data2,
 
-  // Writes
-  input  logic        write_enable,
-  input  logic [31:0] write_data,
-  input  logic [4:0]  address3
+    // Writes
+    input  logic        write_enable,
+    input  logic [31:0] write_data,
+    input  logic [4:0]  address3
 
 );
 
-  // 32 bits register. 32 of them (addressed with 5 bits)
-  reg [31:0] registers [0:31];
+    // 32 bits register. 32 of them (addressed with 5 bits)
+    reg [31:0] registers [0:31];
 
-  // Write logic
-  always @(posedge clk) begin
-    // reset support, init to 0
-    if(rst_n == 1'b0) begin
-      for(int i = 0; i<32; i++) begin
-        registers[i] <= 32'b0;
-      end
+    // Write logic
+    always @(posedge clk) begin
+        // reset support, init to 0
+        if(rst_n == 1'b0) begin
+            for(int i = 0; i<32; i++) begin
+                registers[i] <= 32'b0;
+            end
+        end
+        // Write, except on 0, reserved for a zero constant according to RISC-V specs
+        else if(write_enable == 1'b1 && address3 != 0) begin
+            registers[address3] <= write_data;
+        end
     end
-    // Write, except on 0, reserved for a zero constant according to RISC-V specs
-    else if(write_enable == 1'b1 && address3 != 0) begin
-      registers[address3] <= write_data;
-    end
-  end
 
-  // Read logic, async
-  always_comb begin : read_logic
-    read_data1 = registers[address1];
-    read_data2 = registers[address2];
-  end : read_logic
+    // Read logic, async
+    always_comb begin : read_logic
+        read_data1 = registers[address1];
+        read_data2 = registers[address2];
+    end : read_logic
 
 endmodule : regfile

--- a/0_single_cycle_edition/src/regfile.sv
+++ b/0_single_cycle_edition/src/regfile.sv
@@ -10,44 +10,44 @@
 
 module regfile (
 
-    // Basic signals
-    input  logic        clk,
-    input  logic        rst_n,
+  // Basic signals
+  input  logic        clk,
+  input  logic        rst_n,
 
-    // Reads
-    input  logic [4:0]  address1,
-    input  logic [4:0]  address2,
-    output logic [31:0] read_data1,
-    output logic [31:0] read_data2,
+  // Reads
+  input  logic [4:0]  address1,
+  input  logic [4:0]  address2,
+  output logic [31:0] read_data1,
+  output logic [31:0] read_data2,
 
-    // Writes
-    input  logic        write_enable,
-    input  logic [31:0] write_data,
-    input  logic [4:0]  address3
+  // Writes
+  input  logic        write_enable,
+  input  logic [31:0] write_data,
+  input  logic [4:0]  address3
 
 );
 
-// 32bits register. 32 of them (addressed with 5 bits)
-reg [31:0] registers [0:31]; 
+  // 32 bits register. 32 of them (addressed with 5 bits)
+  reg [31:0] registers [0:31];
 
-// Write logic
-always @(posedge clk) begin
+  // Write logic
+  always @(posedge clk) begin
     // reset support, init to 0
     if(rst_n == 1'b0) begin
-        for(int i = 0; i<32; i++) begin
-            registers[i] <= 32'b0;
-        end
-    end 
+      for(int i = 0; i<32; i++) begin
+        registers[i] <= 32'b0;
+      end
+    end
     // Write, except on 0, reserved for a zero constant according to RISC-V specs
     else if(write_enable == 1'b1 && address3 != 0) begin
-        registers[address3] <= write_data;
+      registers[address3] <= write_data;
     end
-end
+  end
 
-// Read logic, async
-always_comb begin : readLogic
+  // Read logic, async
+  always_comb begin : read_logic
     read_data1 = registers[address1];
     read_data2 = registers[address2];
-end
-    
-endmodule
+  end : read_logic
+
+endmodule : regfile

--- a/0_single_cycle_edition/src/signext.sv
+++ b/0_single_cycle_edition/src/signext.sv
@@ -9,26 +9,26 @@
 `timescale 1ns/1ps
 
 module signext (
-  input  logic [24:0] raw_src,
-  input  logic [2:0]  imm_source,
-  output logic [31:0] immediate
+    input  logic [24:0] raw_src,
+    input  logic [2:0]  imm_source,
+    output logic [31:0] immediate
 );
 
-  always_comb begin
-    case (imm_source)
-      // For I-Types
-      3'b000: immediate = {{20 {raw_src[24]}}, raw_src[24:13]};
-      // For S-types
-      3'b001: immediate = {{20 {raw_src[24]}}, raw_src[24:18], raw_src[4:0]};
-      // For B-types
-      3'b010: immediate = {{20 {raw_src[24]}}, raw_src[0], raw_src[23:18], raw_src[4:1], 1'b0};
-      // For J-types
-      3'b011: immediate = {{12 {raw_src[24]}}, raw_src[12:5], raw_src[13], raw_src[23:14], 1'b0};
-      // For U-Types
-      3'b100: immediate = {raw_src[24:5], 12'b000000000000};
+    always_comb begin
+        case (imm_source)
+            // For I-Types
+            3'b000: immediate = {{20 {raw_src[24]}}, raw_src[24:13]};
+            // For S-types
+            3'b001: immediate = {{20 {raw_src[24]}}, raw_src[24:18], raw_src[4:0]};
+            // For B-types
+            3'b010: immediate = {{20 {raw_src[24]}}, raw_src[0], raw_src[23:18], raw_src[4:1], 1'b0};
+            // For J-types
+            3'b011: immediate = {{12 {raw_src[24]}}, raw_src[12:5], raw_src[13], raw_src[23:14], 1'b0};
+            // For U-Types
+            3'b100: immediate = {raw_src[24:5], 12'b000000000000};
 
-      default: immediate = 32'd0;
-    endcase
-  end
+            default: immediate = 32'd0;
+        endcase
+    end
 
 endmodule : signext

--- a/0_single_cycle_edition/src/signext.sv
+++ b/0_single_cycle_edition/src/signext.sv
@@ -9,26 +9,26 @@
 `timescale 1ns/1ps
 
 module signext (
-    input  logic [24:0] raw_src,
-    input  logic [2:0]  imm_source,
-    output logic [31:0] immediate
+  input  logic [24:0] raw_src,
+  input  logic [2:0]  imm_source,
+  output logic [31:0] immediate
 );
 
-always_comb begin
+  always_comb begin
     case (imm_source)
-        // For I-Types
-        3'b000 : immediate = {{20{raw_src[24]}}, raw_src[24:13]};
-        // For S-types
-        3'b001 : immediate = {{20{raw_src[24]}},raw_src[24:18],raw_src[4:0]};
-        // For B-types
-        3'b010 : immediate = {{20{raw_src[24]}},raw_src[0],raw_src[23:18],raw_src[4:1],1'b0};
-        // For J-types
-        3'b011 : immediate = {{12{raw_src[24]}}, raw_src[12:5], raw_src[13], raw_src[23:14], 1'b0};
-        // For U-Types
-        3'b100 : immediate = {raw_src[24:5],12'b000000000000};
+      // For I-Types
+      3'b000: immediate = {{20 {raw_src[24]}}, raw_src[24:13]};
+      // For S-types
+      3'b001: immediate = {{20 {raw_src[24]}}, raw_src[24:18], raw_src[4:0]};
+      // For B-types
+      3'b010: immediate = {{20 {raw_src[24]}}, raw_src[0], raw_src[23:18], raw_src[4:1], 1'b0};
+      // For J-types
+      3'b011: immediate = {{12 {raw_src[24]}}, raw_src[12:5], raw_src[13], raw_src[23:14], 1'b0};
+      // For U-Types
+      3'b100: immediate = {raw_src[24:5], 12'b000000000000};
 
-        default: immediate = 32'd0;
+      default: immediate = 32'd0;
     endcase
-end
-    
-endmodule
+  end
+
+endmodule : signext


### PR DESCRIPTION
- Correct inner-module indentation for all of the modules.
- [cpu.sv] [Add tabular style to module instantiations](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md#module-instantiation:~:text=Align%20port%20expressions%20in%20tabular%20style.%20Do%20not%20include%20whitespace%20before%20the%20opening%20parenthesis%20of%20the%20longest%20port%20name.%20Do%20not%20include%20whitespace%20after%20the%20opening%20parenthesis%2C%20or%20before%20the%20closing%20parenthesis%20enclosing%20the%20port%20expression.)
- [Fix comma values](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md#comma-delimited-lists:~:text=For%20multiple%20items%20on%20a%20line%2C%20one%20space%20must%20separate%20the%20comma%20and%20the%20next%20character.)
- Some minor changes regarding properly ending SV sequential blocks using block names, etc.