### PR TITLE
[single-cycle] fix(memory): correct $fatal syntax and add read-path alignment check

### DIFF
--- a/0_single_cycle_edition/src/memory.sv
+++ b/0_single_cycle_edition/src/memory.sv
@@ -10,8 +10,8 @@
 `timescale 1ns/1ps
 
 module memory #(
-    parameter WORDS = 128,
-    parameter mem_init = ""
+    parameter int WORDS = 128,
+    parameter string mem_init = ""
 ) (
     input  logic        clk,
     input  logic [31:0] address,
@@ -23,7 +23,7 @@ module memory #(
 );
 
 // Memory array (32-bit words)
-reg [31:0] mem [0:WORDS-1];
+reg [31:0] mem [WORDS];
 
 initial begin
     if (mem_init != "") begin
@@ -40,7 +40,7 @@ always @(posedge clk) begin
     end else begin
         if(write_enable) begin
             if (address[1:0] != 2'b00) begin
-                $fatal("STOPPING SIMULATION: Misaligned write at address %h. HINT: Check your code.", address);
+                $fatal(1, "STOPPING SIMULATION: Misaligned write at address %h. HINT: Check your code.", address);
             end else begin
                 // use byte-enable to selectively write bytes
                 for (int i = 0; i < 4; i++) begin
@@ -56,9 +56,14 @@ always @(posedge clk) begin
 end
 
 always_comb begin
-    /* verilator lint_off WIDTHTRUNC */
-    read_data = mem[address[31:2]];
-    /* verilator lint_on WIDTHTRUNC */
+    read_data = 32'h00000000;
+    if (address[1:0] != 2'b00) begin
+        $fatal(1, "STOPPING SIMULATION: Misaligned read at address %h. HINT: Check your code.", address);
+    end else begin
+        /* verilator lint_off WIDTHTRUNC */
+        read_data = mem[address[31:2]];
+        /* verilator lint_on WIDTHTRUNC */
+    end
 end
 
 endmodule

--- a/0_single_cycle_edition/tb/memory/test_memory.py
+++ b/0_single_cycle_edition/tb/memory/test_memory.py
@@ -22,8 +22,13 @@ async def reset(dut):
     print("reset done !")
 
     # Assert all is 0 after reset
-    for address in range(dut.WORDS.value):
-        dut.address.value = address
+    for word_index in range(dut.WORDS.value):
+
+        # Make the address aligned by using a word index to map to the addresses permitted by the
+        # byte-addressable word-aligned memory array (only the addresses that are multiples of four
+        # are valid).
+        dut.address.value = word_index << 2
+
         await Timer(1, units="ns")
         # just 32 zeroes, you can also use int()
         assert dut.read_data.value == "00000000000000000000000000000000"


### PR DESCRIPTION
- Explicitly define a storage type for `WORDS` (`int`) and `mem_init` (`string`) parameter.
- Use `[WORDS]` shorthand for unpacked array size (equivalent to `[0:WORDS-1]`), no functional change.
- Fix write-path `$fatal` syntax (add `finish_number` = `1`).
- Add address-misalignment check on the read path (mirrors the existing write-path check), with a default drive for `read_data` before the check to avoid incomplete combinational assignment on the `$fatal` branch.